### PR TITLE
Update for Elm 0.18.0

### DIFF
--- a/web/elm/App.elm
+++ b/web/elm/App.elm
@@ -9,7 +9,7 @@ import Html.App
 import Html.Events exposing (onInput, onSubmit)
 
 import Json.Encode as JsEncode
-import Json.Decode as JsDecode exposing ( (:=) )
+import Json.Decode as JsDecode
 
 type alias ChatMessagePayload =
   {
@@ -110,8 +110,7 @@ update msg model =
       )
     ReceiveChatMessage raw ->
       let
-       messageDecoder =
-           "message" := JsDecode.string
+       messageDecoder = JsDecode.field "message" JsDecode.string
        somePayload = JsDecode.decodeValue messageDecoder raw
       in
        case somePayload of

--- a/web/elm/App.elm
+++ b/web/elm/App.elm
@@ -5,7 +5,6 @@ import Phoenix.Channel
 import Phoenix.Push
 
 import Html exposing (Html, div, li, ul, text, form, input, button)
-import Html.App
 import Html.Events exposing (onInput, onSubmit)
 
 import Json.Encode as JsEncode
@@ -135,7 +134,7 @@ subscriptions model =
 
 main : Program Never
 main =
-  Html.App.program
+  Html.program
     {
       init = init,
       view = view,

--- a/web/elm/App.elm
+++ b/web/elm/App.elm
@@ -132,7 +132,7 @@ subscriptions : Model -> Sub Msg
 subscriptions model =
   Phoenix.Socket.listen model.phxSocket PhoenixMsg
 
-main : Program Never
+main : Program Never Model Msg
 main =
   Html.program
     {

--- a/web/elm/elm-package.json
+++ b/web/elm/elm-package.json
@@ -8,9 +8,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-lang/core": "4.0.5 <= v < 5.0.0",
-        "elm-lang/html": "1.1.0 <= v < 2.0.0",
+        "elm-lang/core": "5.1.1 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "fbonetti/elm-phoenix-socket": "2.0.0 <= v < 3.0.0"
     },
-    "elm-version": "0.17.1 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }


### PR DESCRIPTION
JSON.Decode no longer offers `:=`, and `HTML.App` was removed.